### PR TITLE
fix: make the search case-insensitive

### DIFF
--- a/src/Pages/File.php
+++ b/src/Pages/File.php
@@ -138,7 +138,7 @@ class File
         $content  = new Content($document->getContent(), $document->getYAML() ?? []);
 
         $score = 0;
-        $score += mb_substr_count($this->getName(), $query);
+        $score += mb_substr_count(mb_strtolower($this->getName()), $query);
         $score += mb_substr_count($content->getContent(), $query);
 
         if ($metaKeys === []) {

--- a/src/Pages/File.php
+++ b/src/Pages/File.php
@@ -131,6 +131,7 @@ class File
      */
     public function search(string $query, array $metaKeys = []): int
     {
+        $query      = mb_strtolower($query);
         $rawContent = mb_strtolower((string) $this->load(true));
 
         $document = $this->parser->parse($rawContent, false);

--- a/tests/MarkdownPagesTest.php
+++ b/tests/MarkdownPagesTest.php
@@ -391,10 +391,10 @@ final class MarkdownPagesTest extends TestCase
     public function testSearch()
     {
         $markdownPages = new MarkdownPages($this->folderPath, $this->config);
-        $search        = $markdownPages->search('content');
+        $search        = $markdownPages->search('Content');
 
         $this->assertInstanceOf(Results::class, $search);
-        $this->assertSame('content', $search->getQuery());
+        $this->assertSame('Content', $search->getQuery());
 
         $results = $search->getResults();
         $this->assertInstanceOf(Collection::class, $results);


### PR DESCRIPTION
**Description**
This PR makes the `search` functionality case-insensitive.

Fixes #14

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
